### PR TITLE
Add Dark Reader lock

### DIFF
--- a/template.html
+++ b/template.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock"></meta>
     <link rel="stylesheet" href="/styles/main.css">
     <script src="/lib/jquery.js"></script>
     <script src="/main.js"></script>


### PR DESCRIPTION
This is an alternative to https://github.com/darkreader/darkreader/pull/10689

It is better to add this lock on the site itself instead of modifying Dark Reader list since this way you can alter Dark Reader's behavior yourself instead of waiting for Dark Reader release cycle and CWS/Mozilla review timelines.